### PR TITLE
Ocam2k

### DIFF
--- a/pysilico_server/camera_controller/camera_controller.py
+++ b/pysilico_server/camera_controller/camera_controller.py
@@ -180,7 +180,8 @@ class CameraController(Stepable,
                 self._camera.dtype(),
                 self._camera.getBinning(),
                 self._camera.exposureTime(),
-                self._camera.getFrameRate())
+                self._camera.getFrameRate(),
+                self._camera.getParameters())
         return self._cameraStatus
 
     def _publishStatus(self):
@@ -193,3 +194,11 @@ class CameraController(Stepable,
         self._camera.setFrameRate(frameRate)
         with self._mutexStatus:
             self._cameraStatus = None
+
+    @logEnterAndExit('Entering setParameter',
+                     'Executed setParameter')
+    def setParameter(self, name, value):
+        self._camera.setParameter(name, value)
+        with self._mutexStatus:
+            self._cameraStatus = None
+

--- a/pysilico_server/camera_controller/runner.py
+++ b/pysilico_server/camera_controller/runner.py
@@ -19,7 +19,7 @@ class CameraException(Exception):
     pass
 
 
-def ContextWrapper():
+def WithVimbaIfNeeded():
     def wrapperFunc(f):
         @functools.wraps(f)
         def wrapper_vimba(self, *args, **kwds):
@@ -72,6 +72,8 @@ class Runner(BaseRunner):
         elif cameraModel == 'avt':
             self._use_vimba_wrapper = True
             self._createAvtCamera(cameraDeviceSection)
+        elif cameraModel == 'ocam2k':
+            self._createOcam2KCamera(cameraDeviceSection)
         else:
             raise KeyError('Unsupported camera model %s' % cameraModel)
 
@@ -85,7 +87,7 @@ class Runner(BaseRunner):
         self._camera = SimulatedAuxiliaryCamera(cameraName)
         self._setBinning(cameraDeviceSection)
 
-    @ContextWrapper()
+    @WithVimbaIfNeeded()
     def _createAvtCamera(self, cameraDeviceSection):
         from pysilico_server.devices.avtCamera import AvtCamera
         from vimba import Vimba
@@ -99,6 +101,10 @@ class Runner(BaseRunner):
         self._camera = AvtCamera(self._vimbacamera, cameraName)
         self._camera.setStreamBytesPerSecond(streamBytesPerSecond)
         self._setBinning(cameraDeviceSection)
+
+    def _createOcam2KCamera(self, cameraDeviceSection):
+        from pysilico_server.devices.ocam2kCamera import Ocam2KCamera
+        self._camera = Ocam2KCamera()
 
     def _setBinning(self, cameraDeviceSection):
         try:
@@ -132,7 +138,7 @@ class Runner(BaseRunner):
         self._displaySocket = self.rpc().publisherSocket(
             self._zmqPorts.SERVER_DISPLAY_PORT, hwm=1)
 
-    @ContextWrapper()
+    @WithVimbaIfNeeded()
     def _createDevice(self):
 
         self._createCameraDevice()
@@ -148,7 +154,7 @@ class Runner(BaseRunner):
             self._displaySocket,
             self.rpc())
 
-    @ContextWrapper()
+    @WithVimbaIfNeeded()
     def _runLoop(self):
         self._logRunning()
 

--- a/pysilico_server/camera_controller/runner.py
+++ b/pysilico_server/camera_controller/runner.py
@@ -1,4 +1,5 @@
 import os
+import traceback
 import time
 from plico.utils.base_runner import BaseRunner
 from pysilico_server.devices.simulated_camera import \
@@ -72,7 +73,7 @@ class Runner(BaseRunner):
         elif cameraModel == 'avt':
             self._use_vimba_wrapper = True
             self._createAvtCamera(cameraDeviceSection)
-        elif cameraModel == 'ocam2k':
+        elif cameraModel == 'ocam2K':
             self._createOcam2KCamera(cameraDeviceSection)
         else:
             raise KeyError('Unsupported camera model %s' % cameraModel)
@@ -103,8 +104,8 @@ class Runner(BaseRunner):
         self._setBinning(cameraDeviceSection)
 
     def _createOcam2KCamera(self, cameraDeviceSection):
-        from pysilico_server.devices.ocam2kCamera import Ocam2KCamera
-        self._camera = Ocam2KCamera()
+        from pysilico_server.devices.ocam2KCamera import Ocam2KCamera
+        self._camera = Ocam2KCamera('ocam2k')
 
     def _setBinning(self, cameraDeviceSection):
         try:
@@ -181,6 +182,7 @@ class Runner(BaseRunner):
                     delattr(self, '_vimbacamera')
                 time.sleep(1)
             except Exception as e:
+                traceback.print_exc()
                 self._logger.fatal('Unhandled exception: '+str(e))
                 self._isTerminated = True
         return os.EX_OK

--- a/pysilico_server/devices/abstract_camera.py
+++ b/pysilico_server/devices/abstract_camera.py
@@ -65,3 +65,14 @@ class AbstractCamera(with_metaclass(abc.ABCMeta, object)):
     @abc.abstractmethod
     def deinitialize(self):
         assert False
+
+    @abc.abstractmethod
+    def setParameter(self, name, value):
+        assert False
+
+    @abc.abstractmethod
+    def getParameters(self):
+        assert False
+
+
+

--- a/pysilico_server/devices/avtCamera.py
+++ b/pysilico_server/devices/avtCamera.py
@@ -390,3 +390,13 @@ class AvtCamera(AbstractCamera):
             # self._camera.closeCamera()
         except Exception as e:
             self._logger.warn('Failed to close camera:'+str(e))
+
+    @override
+    def setParameter(self, name, value):
+        raise Exception('Parameter %s is not valid' % str(name))
+
+    @override
+    def getParameters(self):
+        return {}
+
+

--- a/pysilico_server/devices/base_simulated_camera.py
+++ b/pysilico_server/devices/base_simulated_camera.py
@@ -47,6 +47,7 @@ class BaseSimulatedCamera(AbstractCamera):
         self._binning = 1
         self._totalFluxPerMilliSecond = 2e6
         self._noiseInCount = 10.
+        self._testCustomParameter = 42
 
         self._lastValidFrame = None
         self._callbackList = []
@@ -167,3 +168,16 @@ class BaseSimulatedCamera(AbstractCamera):
     @override
     def getFrameCounter(self):
         return self._counter
+
+    @override
+    def setParameter(self, name, value):
+        if name == 'testParameter':
+            self._testCustomParameter = value
+        else:
+            raise Exception('Parameter %s is not valid' % str(name))
+
+    @override
+    def getParameters(self):
+        return {'testParameter': self._testCustomParameter}
+
+

--- a/pysilico_server/devices/ocam2KCamera.py
+++ b/pysilico_server/devices/ocam2KCamera.py
@@ -9,67 +9,74 @@ import FliSdk_V2
 from plico.utils.decorator import logEnterAndExit, \
             synchronized, override
 from pysilico_server.devices.abstract_camera import AbstractCamera
+from plico.utils.logger import Logger
+from pysilico.types.camera_frame import CameraFrame
+
+
 
 class Ocam2KLowLevel():
 
     def __init__(self, cameraIndex=0, verbose=True, binning=1, synchro=False, start=True, logFunc=print):
 
+        def myLogFunc(*args):
+            logFunc(' '.join(map(str, args)))
+
         if not binning in [1,2]:
             raise Exception('Binning must be either 1 or 2')
 
-        self.logFunc = logFunc
+        self.logFunc = myLogFunc
         self.started = False
         context = FliSdk_V2.Init()
         self.verbose = verbose
         self.context = context
 
-        if verbose: logFunc("Detection of grabbers...")
+        if verbose: myLogFunc("Detection of grabbers...")
         listOfGrabbers = FliSdk_V2.DetectGrabbers(context)
 
         if len(listOfGrabbers) == 0:
             raise Exception("No grabber detected, exit.")
 
         if verbose:
-            logFunc("Done.")
-            logFunc("List of detected grabber(s):")
+            myLogFunc("Done.")
+            myLogFunc("List of detected grabber(s):")
             for s in listOfGrabbers:
-                logFunc("- " + s)
+                myLogFunc("- " + s)
 
-        if verbose: logFunc("Detection of cameras...")
+        if verbose: myLogFunc("Detection of cameras...")
         listOfCameras = FliSdk_V2.DetectCameras(context)
 
         if len(listOfCameras) == 0:
             raise Exception("No camera detected, exit.")
 
         if verbose:
-            logFunc("Done.")
-            logFunc("List of detected camera(s):")
+            myLogFunc("Done.")
+            myLogFunc("List of detected camera(s):")
             for i,s in enumerate(listOfCameras):
-                logFunc("- " + str(i) + " -> " + s)
+                myLogFunc("- " + str(i) + " -> " + s)
 
         if cameraIndex is None:
             cameraIndex = int(input("Which camera to use? (0, 1, ...) "))
 
-        if verbose: logFunc("Setting camera: " + listOfCameras[cameraIndex])
+        if verbose: myLogFunc("Setting camera: " + listOfCameras[cameraIndex])
         ok = FliSdk_V2.SetCamera(context, listOfCameras[cameraIndex])
 
         if not ok:
             raise Exception("Error while setting camera.")
 
         result = FliSdk_V2.SetMode(context, FliSdk_V2.Mode.Full)
-        if verbose: logFunc("Setting mode full:", result)
+        if verbose: myLogFunc("Setting mode full:", result)
 
         result = FliSdk_V2.FliOcam2K.SetWorkMode(context)
-        if verbose: logFunc('SetWorkMode:', result)
+        if verbose: myLogFunc('SetWorkMode:', result)
 
         isOcam2k = FliSdk_V2.IsOcam2k(context)
-        if verbose: logFunc('IsOcam2K:', isOcam2k)
+        if verbose: myLogFunc('IsOcam2K:', isOcam2k)
 
         result = FliSdk_V2.GetCameraModel(context)
-        if verbose: logFunc('GetCameraModel ', result)
+        if verbose: myLogFunc('GetCameraModel ', result)
 
         result = FliSdk_V2.GetCurrentCameraName(context)
-        if verbose: logFunc('GetCurrentCameraName ', result)
+        if verbose: myLogFunc('GetCurrentCameraName ', result)
 
         ok = FliSdk_V2.Update(context)
         if not ok:
@@ -83,34 +90,34 @@ class Ocam2KLowLevel():
 
         cmd = 'temp on'
         res, response = FliSdk_V2.FliSerialCamera.SendCommand(context, cmd)
-        if verbose: logFunc(cmd+':', res, response)
+        if verbose: myLogFunc(cmd+':', res, response)
 
         width, height = FliSdk_V2.GetCurrentImageDimension(context)
-        if verbose: logFunc('width, height:', width, height)
+        if verbose: myLogFunc('width, height:', width, height)
 
         self._width = width
         self._height = height
 
         result = FliSdk_V2.EnableUnsignedPixel(context, True)
-        if verbose: logFunc('EnableUnsignedPixel:', result)
+        if verbose: myLogFunc('EnableUnsignedPixel:', result)
 
         result = FliSdk_V2.SetBufferSize(context, 1000)
-        if verbose: logFunc('SetBufferSize:', result)
+        if verbose: myLogFunc('SetBufferSize:', result)
 
         result = FliSdk_V2.EnableRingBuffer(context, True)
-        if verbose: logFunc('EnableRingBuffer:', result)
+        if verbose: myLogFunc('EnableRingBuffer:', result)
 
         result = FliSdk_V2.GetImagesCapacity(context)
-        if verbose: logFunc('GetImagesCapacity:', result)
+        if verbose: myLogFunc('GetImagesCapacity:', result)
 
         result = FliSdk_V2.GetBufferSize(context)
-        if verbose: logFunc('GetBufferSize:', result)
+        if verbose: myLogFunc('GetBufferSize:', result)
 
         result = FliSdk_V2.GetImagesCapacity(context)
-        if verbose: logFunc('GetImagesCapacity:', result)
+        if verbose: myLogFunc('GetImagesCapacity:', result)
 
         result = FliSdk_V2.ResetBuffer(context)
-        if verbose: logFunc('ResetBuffer:', result)
+        if verbose: myLogFunc('ResetBuffer:', result)
 
         ok = FliSdk_V2.Update(context)
 
@@ -130,15 +137,15 @@ class Ocam2KLowLevel():
 
         if binning == 1:
             result = FliSdk_V2.FliOcam2K.SetStandardMode(self.context)
-            if verbose: logFunc('SetStandardMode:', result)
-            result = FliSdk_V2.FliSerialCamera.SetFps(context, float(2000))
-            if verbose: logFunc('SetFps(2000):', result)
+            if self.verbose: self.logFunc('SetStandardMode:', result)
+            result = FliSdk_V2.FliSerialCamera.SetFps(self.context, float(2000))
+            if self.verbose: self.logFunc('SetFps(2000):', result)
 
         elif binning == 2:
             result = FliSdk_V2.FliOcam2K.SetBinning2x2Mode(self.context)
-            if verbose: logFunc('SetBinning2x2Mode:', result)
-            result = FliSdk_V2.FliSerialCamera.SetFps(context, float(3600))
-            if verbose: logFunc('SetFps(3600):', result)
+            if self.verbose: self.logFunc('SetBinning2x2Mode:', result)
+            result = FliSdk_V2.FliSerialCamera.SetFps(self.context, float(3600))
+            if self.verbose: self.logFunc('SetFps(3600):', result)
         
         else:
             raise Exception('Binning %s not supported' % str(binning))
@@ -150,29 +157,29 @@ class Ocam2KLowLevel():
         for a short time only, but this mode has a very low latency.
         *userdata* will be passed as-is to the callback function
         as the second argument.'''
-        FliSdk_V2.AddCallbackNewImage(self.context, func, fps, beforeCopy, userdata)
+        FliSdk_V2.AddCallBackNewImage(self.context, func, fps, beforeCopy, userdata)
 
     def start(self):
         if not self.started:
             result = FliSdk_V2.Start(self.context)
-            if self.verbose: logFunc('Start:', result)
+            if self.verbose: self.logFunc('Start:', result)
             self.started = True
 
     def stop(self, force=False):
         if self.started or force:
             result = FliSdk_V2.Stop(self.context)
-            if self.verbose: logFunc('Stop:', result)
+            if self.verbose: self.logFunc('Stop:', result)
             self.started = False
 
     def setFps(self, fps):
         if fps<10 or fps>2000:
             raise Exception('FPS must be between 10 and 2000')
         result = FliSdk_V2.FliSerialCamera.SetFps(self.context, float(fps))
-        if self.verbose: logFunc('SetFps:', result)
+        if self.verbose: self.logFunc('SetFps:', result)
 
     def getFps(self):
         result, fps = FliSdk_V2.FliSerialCamera.GetFps(self.context)
-        if self.verbose: logFunc('GetFps:', result)
+        if self.verbose: self.logFunc('GetFps:', result)
         return fps
 
     def setEMGain(self, emgain):
@@ -180,23 +187,27 @@ class Ocam2KLowLevel():
             raise Exception('EM gain must be between 1 and 400 included')
         cmd = 'gain %d' % emgain
         res, response = FliSdk_V2.FliSerialCamera.SendCommand(self.context, cmd)
-        if self.verbose: logFunc(cmd+':', res, response)
+        if self.verbose: self.logFunc(cmd+':', res, response)
 
     def getEMGain(self):
         cmd = 'gain'
         res, response = FliSdk_V2.FliSerialCamera.SendCommand(self.context, cmd)
-        if self.verbose: logFunc(cmd+':', res, response)
+        if self.verbose: self.logFunc(cmd+':', res, response)
         gain = re.findall(r'\d+', response)[0]
         return int(gain)
 
     def protectionReset(self):
         result = FliSdk_V2.FliOcam2K.ProtectionReset(self.context)
-        if self.verbose: logFunc('ProtectionReset:', result)
+        if self.verbose: self.logFunc('ProtectionReset:', result)
 
     def setSyncro(self, ttsync):
         cmd = 'synchro ' + ('on' if ttsync else 'off')
         res, response = FliSdk_V2.FliSerialCamera.SendCommand(self.context, cmd)
-        logFunc(cmd+':', res, response)
+        self.logFunc(cmd+':', res, response)
+        self._syncro = ttsync
+
+    def getSyncro(self):
+        return self._syncro
 
     def getCurrentIndex(self):
         return FliSdk_V2.GetBufferFilling(self.context)
@@ -217,63 +228,80 @@ class Ocam2KLowLevel():
     def saveFrames(self, nFrames, filename=None):
 
         result = FliSdk_V2.ResetBuffer(self.context)
-        if self.verbose: logFunc('ResetBuffer:', result)
+        if self.verbose: self.logFunc('ResetBuffer:', result)
 
         self.start()
 
         result = FliSdk_V2.EnableGrabN(self.context, nFrames)
-        if self.verbose: logFunc('EnableGrabN:', result)
+        if self.verbose: self.logFunc('EnableGrabN:', result)
 
         while not FliSdk_V2.IsGrabNFinished(self.context):
             result = FliSdk_V2.GetBufferFilling(self.context)
-            if self.verbose: logFunc('GetBufferFilling:', result)
+            if self.verbose: self.logFunc('GetBufferFilling:', result)
             time.sleep(0.1)
 
         result = FliSdk_V2.DisableGrabN(self.context)
-        if self.verbose: logFunc('DisableGrabN:', result)
+        if self.verbose: self.logFunc('DisableGrabN:', result)
 
         if filename:
-            if self.verbose: logFunc('Saving to %s...', filename)
+            if self.verbose: self.logFunc('Saving to %s...', filename)
             result = FliSdk_V2.SaveBuffer(self.context, filename, 0, nFrames)
-            if self.verbose: logFunc('SaveBuffer:', result)
+            if self.verbose: self.logFunc('SaveBuffer:', result)
 
     def getTemperature(self):
         result, *allTemp = FliSdk_V2.FliOcam2K.GetAllTemp(self.context)
-        if self.verbose: logFunc('GetAllTemp:', result)
+        if self.verbose: self.logFunc('GetAllTemp:', result)
         return allTemp[0]
 
     def getTemperatureSetPoint(self):
         result, *allTemp = FliSdk_V2.FliOcam2K.GetAllTemp(self.context)
-        if self.verbose: logFunc('GetAllTemp:', result)
+        if self.verbose: self.logFunc('GetAllTemp:', result)
         return allTemp[7]
 
     def setTemperatureSetPoint(self, setpoint):
         cmd = 'temp %d' % int(setpoint)
         res, response = FliSdk_V2.FliSerialCamera.SendCommand(self.context, cmd)
-        if self.verbose: logFunc(cmd+':', res, response)
+        if self.verbose: self.logFunc(cmd+':', res, response)
 
     def __del__(self):
         self.stop()
         FliSdk_V2.Exit(self.context)
 
 
+class RepeatTimer(threading.Timer):
+    def run(self):
+        while not self.finished.wait(self.interval):
+            self.function(*self.args, **self.kwargs)
+
 class Ocam2KCamera(AbstractCamera):
 
     def __init__(self, name):
         self._logger = Logger.of('Ocam2KCamera')
-        self._camera = Ocam2KCamera(binning=1, logFunc=self._logger.notice)
+        self._camera = Ocam2KLowLevel(binning=1, logFunc=self._logger.notice)
         self._name = name
         self._binning = 1
         self._ncols = self._camera.getWidth()
         self._nrows = self._camera.getHeight()
         self._maxClientFps = 100
         self._mutex = threading.RLock()
+        self._timer = RepeatTimer(0.005, self.timer)
         self._callbackList = []
-        self._camera.addCallback(self._newFrameCallback, self.maxClientFps, beforeCopy=False, userdata=None)
+        self._timer.start()
 
-    def _newFrameCallback(self, frame, userdata):
+       # FliSdk callbacks seem not to work
+       # self._camera.addCallback(self._newFrameCallback, self._maxClientFps, beforeCopy=False, userdata=None)
+
+ #   def _newFrameCallback(self, frame, userdata):
+  #      print(frame)
+  #      print(userdata)
+  #      for callback in self._callbackList:
+   #         callback(frame)
+
+    def timer(self):
+        frame = self.readFrame()
+        cameraFrame = CameraFrame(frame, counter=self.getFrameCounter())
         for callback in self._callbackList:
-            callback(frame)
+            callback(cameraFrame)
 
     @override
     def startAcquisition(self):
@@ -289,7 +317,7 @@ class Ocam2KCamera(AbstractCamera):
 
     @override
     def readFrame(self, timeoutMilliSec=2000):
-        return self._camera.getFrame(index=-1, next=True, timeout=timeutMillisec/1000)
+        return self._camera.getFrame(index=-1, next=True, timeout=timeoutMilliSec/1000)
 
     @override
     @synchronized("_mutex")
@@ -307,7 +335,7 @@ class Ocam2KCamera(AbstractCamera):
 
     @override
     def rows(self):
-        return self._rows/self._binning
+        return self._nrows/self._binning
 
     @override
     def cols(self):
@@ -332,9 +360,8 @@ class Ocam2KCamera(AbstractCamera):
     def setFrameRate(self, frameRate):
         self._camera.setFps(frameRate)
 
-    @override
     @synchronized("_mutex")
-    def frameRate(self):
+    def getFrameRate(self):
         return self._camera.getFps()
 
     @override

--- a/pysilico_server/devices/ocam2KCamera.py
+++ b/pysilico_server/devices/ocam2KCamera.py
@@ -1,0 +1,344 @@
+
+import re
+import time
+import numpy as np
+import threading
+
+import FliSdk_V2
+
+from plico.utils.decorator import logEnterAndExit, \
+            synchronized, override
+from pysilico_server.devices.abstract_camera import AbstractCamera
+
+class Ocam2KLowLevel():
+
+    def __init__(self, cameraIndex=0, verbose=True, binning=1, synchro=False, start=True, logFunc=print):
+
+        if not binning in [1,2]:
+            raise Exception('Binning must be either 1 or 2')
+
+        self.logFunc = logFunc
+        self.started = False
+        context = FliSdk_V2.Init()
+        self.verbose = verbose
+        self.context = context
+
+        if verbose: logFunc("Detection of grabbers...")
+        listOfGrabbers = FliSdk_V2.DetectGrabbers(context)
+
+        if len(listOfGrabbers) == 0:
+            raise Exception("No grabber detected, exit.")
+
+        if verbose:
+            logFunc("Done.")
+            logFunc("List of detected grabber(s):")
+            for s in listOfGrabbers:
+                logFunc("- " + s)
+
+        if verbose: logFunc("Detection of cameras...")
+        listOfCameras = FliSdk_V2.DetectCameras(context)
+
+        if len(listOfCameras) == 0:
+            raise Exception("No camera detected, exit.")
+
+        if verbose:
+            logFunc("Done.")
+            logFunc("List of detected camera(s):")
+            for i,s in enumerate(listOfCameras):
+                logFunc("- " + str(i) + " -> " + s)
+
+        if cameraIndex is None:
+            cameraIndex = int(input("Which camera to use? (0, 1, ...) "))
+
+        if verbose: logFunc("Setting camera: " + listOfCameras[cameraIndex])
+        ok = FliSdk_V2.SetCamera(context, listOfCameras[cameraIndex])
+
+        if not ok:
+            raise Exception("Error while setting camera.")
+
+        result = FliSdk_V2.SetMode(context, FliSdk_V2.Mode.Full)
+        if verbose: logFunc("Setting mode full:", result)
+
+        result = FliSdk_V2.FliOcam2K.SetWorkMode(context)
+        if verbose: logFunc('SetWorkMode:', result)
+
+        isOcam2k = FliSdk_V2.IsOcam2k(context)
+        if verbose: logFunc('IsOcam2K:', isOcam2k)
+
+        result = FliSdk_V2.GetCameraModel(context)
+        if verbose: logFunc('GetCameraModel ', result)
+
+        result = FliSdk_V2.GetCurrentCameraName(context)
+        if verbose: logFunc('GetCurrentCameraName ', result)
+
+        ok = FliSdk_V2.Update(context)
+        if not ok:
+             raise Exception('Error updating SDK with final parameters')
+
+        self.setBinning(binning)
+        self.protectionReset()
+        self.setSyncro(synchro)
+        self.setEMGain(1)
+        self.setTemperatureSetPoint(20)
+
+        cmd = 'temp on'
+        res, response = FliSdk_V2.FliSerialCamera.SendCommand(context, cmd)
+        if verbose: logFunc(cmd+':', res, response)
+
+        width, height = FliSdk_V2.GetCurrentImageDimension(context)
+        if verbose: logFunc('width, height:', width, height)
+
+        result = FliSdk_V2.EnableUnsignedPixel(context, True)
+        if verbose: logFunc('EnableUnsignedPixel:', result)
+
+        result = FliSdk_V2.SetBufferSize(context, 1000)
+        if verbose: logFunc('SetBufferSize:', result)
+
+        result = FliSdk_V2.EnableRingBuffer(context, True)
+        if verbose: logFunc('EnableRingBuffer:', result)
+
+        result = FliSdk_V2.GetImagesCapacity(context)
+        if verbose: logFunc('GetImagesCapacity:', result)
+
+        result = FliSdk_V2.GetBufferSize(context)
+        if verbose: logFunc('GetBufferSize:', result)
+
+        result = FliSdk_V2.GetImagesCapacity(context)
+        if verbose: logFunc('GetImagesCapacity:', result)
+
+        result = FliSdk_V2.ResetBuffer(context)
+        if verbose: logFunc('ResetBuffer:', result)
+
+        ok = FliSdk_V2.Update(context)
+
+        self.stop(force=True)
+        if start:
+            self.start()
+
+        self._lastIndex = None
+
+    def setBinning(self, binning):
+
+        if binning == 1:
+            result = FliSdk_V2.FliOcam2K.SetStandardMode(self.context)
+            if verbose: logFunc('SetStandardMode:', result)
+            result = FliSdk_V2.FliSerialCamera.SetFps(context, float(2000))
+            if verbose: logFunc('SetFps(2000):', result)
+
+        elif binning == 2:
+            result = FliSdk_V2.FliOcam2K.SetBinning2x2Mode(self.context)
+            if verbose: logFunc('SetBinning2x2Mode:', result)
+            result = FliSdk_V2.FliSerialCamera.SetFps(context, float(3600))
+            if verbose: logFunc('SetFps(3600):', result)
+        
+        else:
+            raise Exception('Binning %s not supported' % str(binning))
+
+    def addCallback(self, func, fps, beforeCopy=False, userdata=None):
+        '''Adds a callback for new images that will be called
+        at no more than *fps* Hz. If *beforeCopy* is True, the image
+        will be in the frame grabber memory and be available
+        for a short time only, but this mode has a very low latency.'''
+        FliSdk_V2.AddCallbackNewImage(self.context, func, fps, beforeCop, userdata)
+
+    def start(self):
+        if not self.started:
+            result = FliSdk_V2.Start(self.context)
+            if self.verbose: logFunc('Start:', result)
+            self.started = True
+
+    def stop(self, force=False):
+        if self.started or force:
+            result = FliSdk_V2.Stop(self.context)
+            if self.verbose: logFunc('Stop:', result)
+            self.started = False
+
+    def setFps(self, fps):
+        if fps<10 or fps>2000:
+            raise Exception('FPS must be between 10 and 2000')
+        result = FliSdk_V2.FliSerialCamera.SetFps(self.context, float(fps))
+        if self.verbose: logFunc('SetFps:', result)
+
+    def getFps(self):
+        result, fps = FliSdk_V2.FliSerialCamera.GetFps(self.context)
+        if self.verbose: logFunc('GetFps:', result)
+        return fps
+
+    def setEMGain(self, emgain):
+        if emgain<1 or emgain>400:
+            raise Exception('EM gain must be between 1 and 400 included')
+        cmd = 'gain %d' % emgain
+        res, response = FliSdk_V2.FliSerialCamera.SendCommand(self.context, cmd)
+        if self.verbose: logFunc(cmd+':', res, response)
+
+    def getEMGain(self):
+        cmd = 'gain'
+        res, response = FliSdk_V2.FliSerialCamera.SendCommand(self.context, cmd)
+        if self.verbose: logFunc(cmd+':', res, response)
+        gain = re.findall(r'\d+', response)[0]
+        return int(gain)
+
+    def protectionReset(self):
+        result = FliSdk_V2.FliOcam2K.ProtectionReset(self.context)
+        if self.verbose: logFunc('ProtectionReset:', result)
+
+    def setSyncro(self, ttsync):
+        cmd = 'synchro ' + ('on' if ttsync else 'off')
+        res, response = FliSdk_V2.FliSerialCamera.SendCommand(self.context, cmd)
+        logFunc(cmd+':', res, response)
+
+    def getCurrentIndex(self):
+        return FliSdk_V2.GetBufferFilling(self.context)
+
+    def getFrame(self, index=-1, next=False, timeout=1):
+
+        if next is True:
+             start = time.time()
+             index = self.getCurrentIndex()
+             while index == self._lastIndex:
+                  if time.time()-start > timeout:
+                      raise TimeoutError('Timeout waiting for Ocam2K frames')
+                  index = self.getCurrentIndex()
+             self._lastIndex = index
+ 
+        return FliSdk_V2.GetRawImageAsNumpyArray(self.context, index)
+
+    def saveFrames(self, nFrames, filename=None):
+
+        result = FliSdk_V2.ResetBuffer(self.context)
+        if self.verbose: logFunc('ResetBuffer:', result)
+
+        self.start()
+
+        result = FliSdk_V2.EnableGrabN(self.context, nFrames)
+        if self.verbose: logFunc('EnableGrabN:', result)
+
+        while not FliSdk_V2.IsGrabNFinished(self.context):
+            result = FliSdk_V2.GetBufferFilling(self.context)
+            if self.verbose: logFunc('GetBufferFilling:', result)
+            time.sleep(0.1)
+
+        result = FliSdk_V2.DisableGrabN(self.context)
+        if self.verbose: logFunc('DisableGrabN:', result)
+
+        if filename:
+            if self.verbose: logFunc('Saving to %s...', filename)
+            result = FliSdk_V2.SaveBuffer(self.context, filename, 0, nFrames)
+            if self.verbose: logFunc('SaveBuffer:', result)
+
+    def getTemperature(self):
+        result, *allTemp = FliSdk_V2.FliOcam2K.GetAllTemp(self.context)
+        if self.verbose: logFunc('GetAllTemp:', result)
+        return allTemp[0]
+
+    def getTemperatureSetPoint(self):
+        result, *allTemp = FliSdk_V2.FliOcam2K.GetAllTemp(self.context)
+        if self.verbose: logFunc('GetAllTemp:', result)
+        return allTemp[7]
+
+    def setTemperatureSetPoint(self, setpoint):
+        cmd = 'temp %d' % int(setpoint)
+        res, response = FliSdk_V2.FliSerialCamera.SendCommand(self.context, cmd)
+        if self.verbose: logFunc(cmd+':', res, response)
+
+    def __del__(self):
+        self.stop()
+        FliSdk_V2.Exit(self.context)
+
+
+class Ocam2KCamera(AbstractCamera):
+
+    def __init__(self, name):
+        self._logger = Logger.of('Ocam2KCamera')
+        self._camera = Ocam2KCamera(binning=1, logFunc=self._logger.notice)
+        self._name = name
+        self._binning = 1
+        self._counter = 0
+        self._nrows = 240
+        self._ncols = 240
+        self._maxClientFps = 100
+        self._mutex = threading.RLock()
+        self._callbackList = []
+        self._camera.addCallback(self._newFrameCallback, self.maxClientFps, beforeCopy=False, userdata=None)
+
+    def _newFrameCallback(self, frame, userdata):
+        for callback in self._callbackList:
+            callback(frame)
+
+    @override
+    def startAcquisition(self):
+        pass
+
+    @override
+    def stopAcquisition(self):
+        pass
+
+    @override
+    def getFrameCounter(self):
+        return self._camera.getCurrentIndex()
+
+    @override
+    def readFrame(self, timeoutMilliSec=2000):
+        return self._camera.getFrame(index=-1, next=True, timeout=timeutMillisec/1000)
+
+    @override
+    @synchronized("_mutex")
+    def setBinning(self, binning):
+        self._camera.setBinning(binning)
+        self._binning = binning
+
+    @override
+    def getBinning(self):
+        return self._binning
+
+    @override
+    def name(self):
+        return self._name
+
+    @override
+    def rows(self):
+        return self._rows/self._binning
+
+    @override
+    def cols(self):
+        return self._ncols/self._binning
+
+    @override
+    def dtype(self):
+        return np.uint16
+
+    @override
+    @synchronized("_mutex")
+    def setExposureTime(self, exposureTimeInMilliSeconds):
+        self._camera.setFps(1000/exposureTimeInMilliSeconds)
+
+    @override
+    @synchronized("_mutex")
+    def exposureTime(self):
+        return self._camera.getFps()
+
+    @override
+    @synchronized("_mutex")
+    def setFrameRate(self, frameRate):
+        self._camera.setFps(frameRate)
+
+    @override
+    @synchronized("_mutex")
+    def frameRate(self):
+        return self._camera.getFps()
+
+    @override
+    def registerCallback(self, callback):
+        self._callbackList.append(callback)
+
+    @override
+    def getFrameCounter(self):
+        return self._counter
+
+    @override
+    def deinitialize(self):
+        pass
+
+
+
+

--- a/pysilico_server/devices/ocam2KCamera.py
+++ b/pysilico_server/devices/ocam2KCamera.py
@@ -12,6 +12,17 @@ from pysilico_server.devices.abstract_camera import AbstractCamera
 from plico.utils.logger import Logger
 from pysilico.types.camera_frame import CameraFrame
 
+# Example of bash script to set environment variables
+# and also the current directory before starting
+'''
+BASEDIR=/opt/FirstLightImaging
+
+export PYTHONPATH=$BASEDIR/FliSdk/Python/lib
+export LD_LIBRARY_PATH=/home/labot/anaconda3/envs/p37/lib:$BASEDIR/FirstLightVision/lib
+
+(cd $BASEDIR/FirstLightVision && pysilico_start)
+'''
+
 
 
 class Ocam2KLowLevel():


### PR DESCRIPTION
Adding Ocam2KCamera
Since this camera has lots of custom parameters that we do not want to explicitly add to the camera client, a new command setParameter(name, value) can be used to set arbitrary parameters. The current parameter values can be found in the last member of the CameraStatus structure, with contents that are camera-dependent